### PR TITLE
Support swift concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,95 @@ name: CI
 
 on:
   push:
+    branches:
+      - "main"
   pull_request:
+  workflow_dispatch:
 
 jobs:
-  xcode13:
-    name: "Big Sur (Xcode 13.2.1)"
-    runs-on: macos-11
+  xcode14_1:
+    name: "Big Sur (Xcode 14.1) (Swift 5.7.1)"
+    runs-on: macos-12
+
+    env:
+      SCHEME: Stub
+    strategy:
+      matrix:
+        env:
+          - sdk: iphonesimulator
+            destination: platform=iOS Simulator,name=iPhone 14 Pro,OS=latest
+
+          - sdk: macosx
+            destination: arch=x86_64
+
+          - sdk: appletvsimulator
+            destination: platform=tvOS Simulator,name=Apple TV,OS=latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Select Xcode 14.1
+        run: sudo xcode-select -s /Applications/Xcode_14.1.app
+
+      - name: List SDKs and Devices
+        run: xcodebuild -showsdks;
+
+      - name: Build and Test
+        run: |
+          set -o pipefail && xcodebuild clean build test \
+            -scheme "$SCHEME" \
+            -sdk "$SDK" \
+            -destination "$DESTINATION" \
+            -configuration Debug \
+            -enableCodeCoverage YES \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c;
+        env:
+          SDK: ${{ matrix.env.sdk }}
+          DESTINATION: ${{ matrix.env.destination }}
+
+  xcode13_4_1:
+    name: "Big Sur (Xcode 13.4.1) (Swift 5.6.1)"
+    runs-on: macos-12
+
+    env:
+      SCHEME: Stub
+    strategy:
+      matrix:
+        env:
+          - sdk: iphonesimulator
+            destination: platform=iOS Simulator,name=iPhone 13 Pro,OS=latest
+
+          - sdk: macosx
+            destination: arch=x86_64
+
+          - sdk: appletvsimulator
+            destination: platform=tvOS Simulator,name=Apple TV,OS=latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Select Xcode 13.4.1
+        run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
+
+      - name: List SDKs and Devices
+        run: xcodebuild -showsdks;
+
+      - name: Build and Test
+        run: |
+          set -o pipefail && xcodebuild clean build test \
+            -scheme "$SCHEME" \
+            -sdk "$SDK" \
+            -destination "$DESTINATION" \
+            -configuration Debug \
+            -enableCodeCoverage YES \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty -c;
+        env:
+          SDK: ${{ matrix.env.sdk }}
+          DESTINATION: ${{ matrix.env.destination }}
+
+  xcode13_2_1:
+    name: "Big Sur (Xcode 13.2.1) (Swift 5.5.2)"
+    runs-on: macos-12
 
     env:
       SCHEME: Stub

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ final class StubUserService: UserServiceProtocol {
   func edit(userID: Int, name: String) -> Bool {
     editStub.invoke((userID, name), default: false)
   }
+
+
+  // when use async function
+
+  @AsyncStubProxy(upload) var uploadStub
+  func upload(image: UIImage) async throws -> URL {
+    await uploadStub.invoke(image, default: URL(string: "https://")!)
+  }
 }
 
 func testMethodCall() {
@@ -35,6 +43,22 @@ func testMethodCall() {
   XCTAssertEqual(executions[0].arguments, 123)
   XCTAssertEqual(executions[0].result, "stub-123")
 }
+
+func testAsyncMethodCall() async {
+  // given
+  let userService = StubUserService()
+  await userService.uploadStub.register { image in URL(string: "https://hello.com")! } // stub
+  let image = UIImage("profile")
+
+  // when
+  await userService.upload(image: image) // call
+
+  // then
+  let executions = await userService.followStub.executions()
+  XCTAssertEqual(executions.count, 1)
+  XCTAssertEqual(executions[0].arguments, image)
+  XCTAssertEqual(executions[0].result, URL(string: "https://hello.com")!)
+}
 ```
 
 ## Usage
@@ -45,6 +69,14 @@ func testMethodCall() {
 @StubProxy(fetchOverview) var fetchOverviewStub
 func fetchOverview(id: String) -> Overview {
   fetchOverviewStub.invoke(id, default: Overview.fixture)
+}
+```
+
+When use async function
+```swift
+@AsyncStubProxy(fetchOverview) var fetchOverviewStub
+func fetchOverview(id: String) async -> Overview {
+  await fetchOverviewStub.invoke(id, default: Overview.fixture)
 }
 ```
 
@@ -59,6 +91,14 @@ func fetchOverview(id: String) -> Overview {
 }
 ```
 
+When use async function
+```swift
+@AsyncStubProxy(fetchOverview) var fetchOverviewStub
+func fetchOverview(id: String) async -> Overview {
+  await fetchOverviewStub.invokeWithoutDefault(id)
+}
+```
+
 ### Generic
 
 ```swift
@@ -66,6 +106,15 @@ let convertStubStore = StubStore()
 func convert<Source, Target>(_ source: Source) -> Target {
   let stub = convertStubStore.stub(arguments: Source.self, result: Target.self)
   return stub.invokeWithoutDefault(value)
+}
+```
+
+When use async function
+```swift
+let convertStubStore = StubStore()
+func convert<Source, Target>(_ source: Source) async -> Target {
+  let stub = convertStubStore.asyncStub(arguments: Source.self, result: Target.self)
+  return await stub.invokeWithoutDefault(value)
 }
 ```
 

--- a/Sources/Stub/AsyncStub.swift
+++ b/Sources/Stub/AsyncStub.swift
@@ -1,0 +1,173 @@
+//
+//  AsyncStub.swift
+//  Stub
+//
+//  Created by tokijh on 2022/04/25.
+//  Copyright © 2022 tokijh. All rights reserved.
+//
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public final class AsyncStub<Arguments, Result>: AnyStub {
+
+  // MARK: Module
+
+  public typealias Execution = Stub<Arguments, Result>.Execution
+  public typealias Error = Stub<Arguments, Result>.Error
+
+  // MARK: Properties
+
+  private var stub: ((Arguments) async throws -> Result)?
+  private let executionList: ExecutionList<Arguments, Result> = ExecutionList(executions: [])
+
+  private var clearAllObserver: Notifier.Observer?
+
+  public var isStubbing: Bool { self.stub != nil }
+
+
+  // MARK: Initializer
+
+  public init(arguments: Arguments.Type, result: Result.Type) {
+    self.bind()
+  }
+
+  public convenience init(_ function: (Arguments) async throws -> Result) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+
+  // MARK: Binding
+
+  private func bind() {
+    self.clearAllObserver = subscribeClearAll()
+  }
+
+
+  // MARK: Register
+
+  public func register(_ function: @escaping (Arguments) async throws -> Result) async {
+    self.stub = function
+    await self.executionList.clear()
+  }
+
+
+  // MARK: Invoke
+
+  public func invoke(
+    _ arguments: Arguments,
+    default: @autoclosure () async throws -> Result
+  ) async rethrows -> Result {
+    let result: Result = try await {
+      if let stub = self.stub {
+        return try await stub(arguments)
+      } else {
+        return try await `default`()
+      }
+    }()
+    await self.executionList.append(execution: Execution(arguments: arguments, result: result))
+    return result
+  }
+
+  public func invokeWithoutDefault(
+    _ arguments: Arguments,
+    file: StaticString = #file,
+    line: UInt = #line,
+    function: StaticString = #function
+  ) async -> Result {
+    guard let result = try? await self.stub?(arguments) else {
+      preconditionFailure("⚠️ '\(function)' is not stubbed.", file: file, line: line)
+    }
+    await self.executionList.append(execution: Execution(arguments: arguments, result: result))
+    return result
+  }
+
+  public func invokeThrowWithoutDefault(
+    _ arguments: Arguments,
+    file: StaticString = #file,
+    line: UInt = #line,
+    function: StaticString = #function
+  ) async throws -> Result {
+    guard let result = try await self.stub?(arguments) else {
+      throw Error.notStubbed(function: function, file: file, line: line)
+    }
+    await self.executionList.append(execution: Execution(arguments: arguments, result: result))
+    return result
+  }
+
+
+  // MARK: Executions
+
+  public func executions() async -> [Execution<Arguments, Result>] {
+    await self.executionList.executions
+  }
+
+
+  // MARK: Clear
+
+  public func clear() async {
+    self.stub = nil
+    await self.executionList.clear()
+  }
+
+}
+
+
+// MARK: Model
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub {
+
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  private actor ExecutionList<Arguments, Result> {
+
+    var executions: [Execution<Arguments, Result>]
+
+    init(executions: [Execution<Arguments, Result>] = []) {
+      self.executions = executions
+    }
+
+    func append(execution: Execution<Arguments, Result>) {
+      executions.append(execution)
+    }
+
+    func clear() {
+      executions = []
+    }
+  }
+
+}
+
+
+// MARK: Sugars
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub where Arguments == Void {
+  public func invoke(default: Result) async -> Result {
+    await self.invoke(Void(), default: `default`)
+  }
+
+  public func invokeWithoutDefault(
+    file: StaticString = #file,
+    line: UInt = #line,
+    function: StaticString = #function
+  ) async -> Result {
+    await self.invokeWithoutDefault(Void(), file: file, line: line, function: function)
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub where Result == Void {
+  public func invoke(_ arguments: Arguments) async -> Result {
+    await self.invoke(arguments, default: Void())
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub where Arguments == Void, Result == Void {
+  public func invoke() async -> Result {
+    await self.invoke(Void(), default: Void())
+  }
+}
+
+#endif

--- a/Sources/Stub/Notifier/Notifier+ClearAll.swift
+++ b/Sources/Stub/Notifier/Notifier+ClearAll.swift
@@ -21,11 +21,11 @@ extension Stub where Arguments == Any, Result == Any {
 }
 
 extension Notifier {
-  fileprivate func clearAll() {
+  func clearAll() {
     notificationCenter.post(name: .clearAll, object: nil)
   }
 
-  fileprivate func observeClearAll(_ handler: @escaping () -> ()) -> Observer {
+  func observeClearAll(_ handler: @escaping () -> ()) -> Observer {
     let observer = notificationCenter.addObserver(
       forName: .clearAll,
       object: nil,

--- a/Sources/Stub/Notifier/Notifier+Concurrency+ClearAll.swift
+++ b/Sources/Stub/Notifier/Notifier+Concurrency+ClearAll.swift
@@ -1,0 +1,30 @@
+//
+//  Notifier+Concurrency+ClearAll.swift
+//  Stub
+//
+//  Created by tokijh on 2022/04/25.
+//  Copyright © 2022 tokijh. All rights reserved.
+//
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub {
+  func subscribeClearAll() -> Notifier.Observer {
+    Notifier.shared.observeClearAll { [weak self] in
+      guard let stub = self else { return }
+      Task {
+        await stub.clear()
+      }
+    }
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStub where Arguments == Any, Result == Any {
+  public static func clearAll() {
+    Notifier.shared.clearAll()
+  }
+}
+
+#endif

--- a/Sources/Stub/StubProxy/AsyncStubProxy+ArgumentsInitializer.erb
+++ b/Sources/Stub/StubProxy/AsyncStubProxy+ArgumentsInitializer.erb
@@ -1,0 +1,23 @@
+<% puts "// WARNING: This swift file is auto generated. Don't modify this file directly.\n" %>
+<% arguments = 2..20 %>
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStubProxy {
+
+<%
+  for arg in arguments
+    arguments_range = 1..arg
+
+    arguments_arr = arguments_range.map { |i| "Arg#{i}" }
+    arguments_arr = arguments_arr.join(", ")
+%>
+  public init<Service, <%= arguments_arr %>>(_ function: (Service) -> (<%= arguments_arr %>) async throws -> Result) where Arguments == (<%= arguments_arr %>) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+<% end %>
+}
+
+#endif

--- a/Sources/Stub/StubProxy/AsyncStubProxy+ArgumentsInitializer.swift
+++ b/Sources/Stub/StubProxy/AsyncStubProxy+ArgumentsInitializer.swift
@@ -1,0 +1,86 @@
+// WARNING: This swift file is auto generated. Don't modify this file directly.
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStubProxy {
+
+  public init<Service, Arg1, Arg2>(_ function: (Service) -> (Arg1, Arg2) async throws -> Result) where Arguments == (Arg1, Arg2) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3>(_ function: (Service) -> (Arg1, Arg2, Arg3) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service, Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19, Arg20>(_ function: (Service) -> (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19, Arg20) async throws -> Result) where Arguments == (Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10, Arg11, Arg12, Arg13, Arg14, Arg15, Arg16, Arg17, Arg18, Arg19, Arg20) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+}
+
+#endif

--- a/Sources/Stub/StubProxy/AsyncStubProxy.swift
+++ b/Sources/Stub/StubProxy/AsyncStubProxy.swift
@@ -1,0 +1,31 @@
+//
+//  AsyncStubProxy.swift
+//  
+//
+//  Created by 윤중현 on 2022/11/05.
+//
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@propertyWrapper
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public struct AsyncStubProxy<Arguments, Result> {
+  public let wrappedValue: AsyncStub<Arguments, Result>
+
+  public init(arguments: Arguments.Type, result: Result.Type) {
+    self.wrappedValue = AsyncStub(arguments: arguments, result: result)
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension AsyncStubProxy {
+  public init<Service>(_ function: (Service) -> (Arguments) async throws -> Result) {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+
+  public init<Service>(_ function: (Service) -> () async throws -> Result) where Arguments == Void {
+    self.init(arguments: Arguments.self, result: Result.self)
+  }
+}
+
+#endif

--- a/Sources/Stub/StubStore.swift
+++ b/Sources/Stub/StubStore.swift
@@ -72,6 +72,51 @@ extension StubStore {
 }
 
 
+#if swift(>=5.6) && canImport(_Concurrency)
+
+// MARK: AsyncStub
+
+extension StubStore {
+
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  private func asyncStub<Arguments, Result>(
+    privateKey key: PrivateKey,
+    arguments: Arguments.Type,
+    result: Result.Type
+  ) -> AsyncStub<Arguments, Result> {
+    if let stub = stubs[key] as? AsyncStub<Arguments, Result> {
+      return stub
+    } else {
+      let stub = AsyncStub(arguments: arguments, result: result)
+      stubs[key] = stub
+      return stub
+    }
+  }
+
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public func asyncStub<Arguments, Result>(
+    key: PublicKey,
+    arguments: Arguments.Type,
+    result: Result.Type
+  ) -> AsyncStub<Arguments, Result> {
+    let privateKey = key.toPrivateKey()
+    return asyncStub(privateKey: privateKey, arguments: arguments, result: result)
+  }
+
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  public func asyncStub<Arguments, Result>(
+    arguments: Arguments.Type,
+    result: Result.Type
+  ) -> AsyncStub<Arguments, Result> {
+    let privateKey = PrivateKey.generate(arguments: arguments, result: result)
+    return asyncStub(privateKey: privateKey, arguments: arguments, result: result)
+  }
+
+}
+
+#endif
+
+
 // MARK: Key
 
 extension StubStore.PrivateKey {

--- a/Tests/StubTests/AsyncStubTests.swift
+++ b/Tests/StubTests/AsyncStubTests.swift
@@ -1,0 +1,322 @@
+//
+//  AsyncStubTests.swift
+//  StubTests
+//
+//  Created by tokijh on 2022/11/05.
+//  Copyright © 2022 tokijh. All rights reserved.
+//
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+import XCTest
+import Stub
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+final class AsyncStubTests: XCTestCase {
+
+  override func setUp() {
+    super.setUp()
+    Stub.clearAll()
+  }
+
+  func test_arguments0_defaultNo_returnVoid() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments0_returnVoid_defaultNo_stub
+
+    await stub.register { }
+
+    // when
+    await stubClass.arguments0_returnVoid_defaultNo()
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+  }
+
+  func test_arguments0_defaultVoid_returnVoid() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments0_returnVoid_defaultVoid_stub
+
+    // when
+    await stubClass.arguments0_returnVoid_defaultVoid()
+    await stubClass.arguments0_returnVoid_defaultVoid()
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 2)
+  }
+
+  func test_arguments1_defaultNo_returnInt() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments1_returnInt_defaultNo_stub
+
+    await stub.register { _ in 10 }
+
+    // when
+    let result = await stubClass.arguments1_returnInt_defaultNo("Hello")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments, "Hello")
+    XCTAssertEqual(executions[0].result, 10)
+    XCTAssertEqual(result, 10)
+  }
+
+  func test_arguments1_defaultInt_returnInt() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments1_returnInt_defaultInt_stub
+
+    // when
+    let result = await stubClass.arguments1_returnInt_defaultInt("Hello, default!")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments, "Hello, default!")
+    XCTAssertEqual(executions[0].result, 0)
+    XCTAssertEqual(result, 0)
+  }
+
+  func test_arguments1_parameterOptional_returnBool_defaultNo() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments1_parameterOptional_returnBool_defaultNo_stub
+
+    await stub.register { _ in true }
+
+    // when
+    let result = await stubClass.arguments1_parameterOptional_returnBool_defaultNo("String Parameter")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments, "String Parameter")
+    XCTAssertEqual(executions[0].result, true)
+    XCTAssertEqual(result, true)
+  }
+
+  func test_arguments1_parameterOptional_returnBool_defaultBool() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments1_parameterOptional_returnBool_defaultBool_stub
+
+    // when
+    let result = await stubClass.arguments1_parameterOptional_returnBool_defaultBool("String Value")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments, "String Value")
+    XCTAssertEqual(executions[0].result, false)
+    XCTAssertEqual(result, false)
+  }
+
+  func test_arguments2_parameterOptional_returnBool_defaultNo() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments2_parameterOptional_returnBool_defaultNo_stub
+
+    await stub.register { _ in true }
+
+    // when
+    let result = await stubClass.arguments2_parameterOptional_returnBool_defaultNo("String1", "String2")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "String1")
+    XCTAssertEqual(executions[0].arguments.1, "String2")
+    XCTAssertEqual(executions[0].result, true)
+    XCTAssertEqual(result, true)
+  }
+
+  func test_arguments2_parameterOptional_returnBool_defaultBool() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments2_parameterOptional_returnBool_defaultBool_stub
+
+    // when
+    let result = await stubClass.arguments2_parameterOptional_returnBool_defaultBool("String Value1", "String Value2")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "String Value1")
+    XCTAssertEqual(executions[0].arguments.1, "String Value2")
+    XCTAssertEqual(executions[0].result, false)
+    XCTAssertEqual(result, false)
+  }
+
+  func test_arguments3_returnOptionalString_defaultNo() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments3_returnOptionalString_defaultNo_stub
+
+    await stub.register { _ in "Test" }
+
+    // when
+    let result = await stubClass.arguments3_returnOptionalString_defaultNo("Hello", 10, 20)
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "Hello")
+    XCTAssertEqual(executions[0].arguments.1, 10)
+    XCTAssertEqual(executions[0].arguments.2, 20)
+    XCTAssertEqual(executions[0].result, "Test")
+    XCTAssertEqual(result, "Test")
+  }
+
+  func test_arguments3_returnOptionalString_defaultString() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments3_returnOptionalString_defaultString_stub
+
+    // when
+    let result = await stubClass.arguments3_returnOptionalString_defaultString("Hello", 10, 20)
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "Hello")
+    XCTAssertEqual(executions[0].arguments.1, 10)
+    XCTAssertEqual(executions[0].arguments.2, 20)
+    XCTAssertEqual(executions[0].result, "default")
+    XCTAssertEqual(result, "default")
+  }
+
+  func test_arguments0_returnOptionalInt_defaultNil() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments0_returnOptionalInt_defaultNil_stub
+
+    // when
+    let result = await stubClass.arguments0_returnOptionalInt_defaultNil()
+
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertNil(executions[0].result)
+    XCTAssertNil(result)
+  }
+
+  func test_arguments2_returnString_defaultNo_throws() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments2_returnString_defaultNo_throws_stub
+
+    await stub.register { _ in "Stubbed" }
+
+    // when
+    let result = try? await stubClass.arguments2_returnString_defaultNo_throws("Hello", 30)
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "Hello")
+    XCTAssertEqual(executions[0].arguments.1, 30)
+    XCTAssertEqual(executions[0].result, "Stubbed")
+    XCTAssertEqual(result, "Stubbed")
+  }
+
+  func test_arguments2_returnString_defaultString_throws() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments2_returnString_defaultString_throws_stub
+
+    // when
+    let result = try? await stubClass.arguments2_returnString_defaultString_throws("Hello", 30)
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments.0, "Hello")
+    XCTAssertEqual(executions[0].arguments.1, 30)
+    XCTAssertEqual(executions[0].result, "default")
+    XCTAssertEqual(result, "default")
+  }
+
+  func test_arguments_1_generic() async {
+    // given
+    let stubClass = AsyncStubClass()
+    let stub = stubClass.arguments_1_generic_stubStore.asyncStub(arguments: String.self, result: String.self)
+
+    await stub.register { _ in "Stubbed" }
+
+    // when
+    let result: String = await stubClass.arguments_1_generic("Hi")
+
+    // then
+    let executions = await stub.executions()
+    XCTAssertEqual(executions.count, 1)
+    XCTAssertEqual(executions[0].arguments, "Hi")
+    XCTAssertEqual(executions[0].result, "Stubbed")
+    XCTAssertEqual(result, "Stubbed")
+  }
+
+  func testThreadSafety() async {
+    // given
+    let stubClass = AsyncStubClass()
+
+    // when & then (must have to not crash)
+    for _ in 0..<100 {
+      Task(priority: .background) { try await stubClass.sleep() }
+      Task.detached(priority: .background) { try await stubClass.sleep() }
+      DispatchQueue.global().async {
+        Task { try await stubClass.sleep() }
+      }
+    }
+    XCTWaiter().wait(for: [XCTestExpectation()], timeout: 10)
+
+    // then
+    let executions = await stubClass.sleep_stub.executions()
+    XCTAssertEqual(executions.count, 300)
+  }
+
+  func testClosureCrash() async {
+    // given
+    final class ImageManager {
+      @AsyncStubProxy(requestImage) var requestImageStub
+      func requestImage(for asset: AnyObject, resultHandler: (() -> Void)? = nil) async {
+        await requestImageStub.invoke((asset, resultHandler))
+      }
+    }
+
+    let imageManager = ImageManager()
+    await imageManager.requestImage(for: NSObject())
+
+    let executions = await imageManager.requestImageStub.executions()
+
+    // crash
+    _ = executions.first?.arguments.0
+    await imageManager.requestImageStub.clear()
+  }
+
+  func testMatcherArgumentsNil() async {
+    // given
+    final class Foo {
+      @AsyncStubProxy(doSomething) var doSomethingStub
+      func doSomething(with arg: String?) async {
+        await doSomethingStub.invoke(arg)
+      }
+    }
+
+    func expect<T>(_ value: T, toHaveCount count: Int, file: StaticString = #file, line: UInt = #line, where: @escaping (T.Iterator.Element) -> Bool) where T: Collection {
+      XCTAssertEqual(value.filter(`where`).count, count, file: file, line: line)
+    }
+
+    let foo = Foo()
+    await foo.doSomething(with: nil)
+
+    let executions = await foo.doSomethingStub.executions()
+    expect(executions, toHaveCount: 1) {
+      $0.arguments == nil
+    }
+  }
+}
+
+#endif

--- a/Tests/StubTests/AsyncStubs.swift
+++ b/Tests/StubTests/AsyncStubs.swift
@@ -1,0 +1,109 @@
+//
+//  Stubs.swift
+//  StubTests
+//
+//  Created by tokijh on 2022/11/05.
+//  Copyright © 2022 tokijh. All rights reserved.
+//
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+import Stub
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+final class AsyncStubClass {
+
+  @AsyncStubProxy(arguments0_returnVoid_defaultNo)
+  var arguments0_returnVoid_defaultNo_stub
+  func arguments0_returnVoid_defaultNo() async {
+    await arguments0_returnVoid_defaultNo_stub.invoke()
+  }
+  @AsyncStubProxy(arguments0_returnVoid_defaultVoid)
+  var arguments0_returnVoid_defaultVoid_stub
+  func arguments0_returnVoid_defaultVoid() async {
+    await arguments0_returnVoid_defaultVoid_stub.invoke()
+  }
+
+  @AsyncStubProxy(arguments1_returnInt_defaultNo)
+  var arguments1_returnInt_defaultNo_stub
+  func arguments1_returnInt_defaultNo(_ value: String) async -> Int {
+    await arguments1_returnInt_defaultNo_stub.invokeWithoutDefault(value)
+  }
+  @AsyncStubProxy(arguments1_returnInt_defaultInt)
+  var arguments1_returnInt_defaultInt_stub
+  func arguments1_returnInt_defaultInt(_ value: String) async -> Int {
+    await arguments1_returnInt_defaultInt_stub.invoke(value, default: 0)
+  }
+
+  @AsyncStubProxy(arguments1_parameterOptional_returnBool_defaultNo)
+  var arguments1_parameterOptional_returnBool_defaultNo_stub
+  func arguments1_parameterOptional_returnBool_defaultNo(_ value: String?) async -> Bool {
+    await arguments1_parameterOptional_returnBool_defaultNo_stub.invokeWithoutDefault(value)
+  }
+  @AsyncStubProxy(arguments1_parameterOptional_returnBool_defaultBool)
+  var arguments1_parameterOptional_returnBool_defaultBool_stub
+  func arguments1_parameterOptional_returnBool_defaultBool(_ value: String?) async -> Bool {
+    await arguments1_parameterOptional_returnBool_defaultBool_stub.invoke(value, default: false)
+  }
+
+  @AsyncStubProxy(arguments2_parameterOptional_returnBool_defaultNo)
+  var arguments2_parameterOptional_returnBool_defaultNo_stub
+  func arguments2_parameterOptional_returnBool_defaultNo(_ value1: String?, _ value2: String) async -> Bool {
+    await arguments2_parameterOptional_returnBool_defaultNo_stub.invokeWithoutDefault((value1, value2))
+  }
+  @AsyncStubProxy(arguments2_parameterOptional_returnBool_defaultBool)
+  var arguments2_parameterOptional_returnBool_defaultBool_stub
+  func arguments2_parameterOptional_returnBool_defaultBool(_ value1: String?, _ value2: String) async -> Bool {
+    await arguments2_parameterOptional_returnBool_defaultBool_stub.invoke((value1, value2), default: false)
+  }
+
+  @AsyncStubProxy(arguments3_returnOptionalString_defaultNo)
+  var arguments3_returnOptionalString_defaultNo_stub
+  func arguments3_returnOptionalString_defaultNo(_ value1: String, _ value2: Int, _ value3: Float) async -> String? {
+    await arguments3_returnOptionalString_defaultNo_stub.invokeWithoutDefault((value1, value2, value3))
+  }
+  @AsyncStubProxy(arguments3_returnOptionalString_defaultString)
+  var arguments3_returnOptionalString_defaultString_stub
+  func arguments3_returnOptionalString_defaultString(_ value1: String, _ value2: Int, _ value3: Float) async -> String? {
+    await arguments3_returnOptionalString_defaultString_stub.invoke((value1, value2, value3), default: "default")
+  }
+
+  @AsyncStubProxy(arguments0_returnOptionalInt_defaultNil)
+  var arguments0_returnOptionalInt_defaultNil_stub
+  func arguments0_returnOptionalInt_defaultNil() async -> Int? {
+    await arguments0_returnOptionalInt_defaultNil_stub.invoke(default: nil)
+  }
+
+  @AsyncStubProxy(arguments2_returnString_defaultNo_throws)
+  var arguments2_returnString_defaultNo_throws_stub
+  func arguments2_returnString_defaultNo_throws(_ value1: String, _ value2: Int) async throws -> String {
+    try await arguments2_returnString_defaultNo_throws_stub.invokeThrowWithoutDefault((value1, value2))
+  }
+  @AsyncStubProxy(arguments2_returnString_defaultString_throws)
+  var arguments2_returnString_defaultString_throws_stub
+  func arguments2_returnString_defaultString_throws(_ value1: String, _ value2: Int) async throws -> String {
+    await arguments2_returnString_defaultString_throws_stub.invoke((value1, value2), default: "default")
+  }
+
+  @AsyncStubProxy(arguments_escapeClosure)
+  var arguments_escapeClosure_stub
+  func arguments_escapeClosure(_ value1: String, _ value2: @escaping (Bool) -> String) async -> Void {
+    await arguments_escapeClosure_stub.invoke((value1, value2))
+  }
+
+  let arguments_1_generic_stubStore = StubStore()
+  func arguments_1_generic<T>(_ value: T) async -> T {
+    let stub = arguments_1_generic_stubStore.asyncStub(arguments: T.self, result: T.self)
+    return await stub.invokeWithoutDefault(value)
+  }
+
+  @AsyncStubProxy(sleep)
+  var sleep_stub
+  func sleep() async throws {
+    await sleep_stub.invoke(default: try await {
+      try await Task.sleep(nanoseconds: 1_000_000_000) // 1s
+    }())
+  }
+}
+
+#endif

--- a/Tests/StubTests/ClearAllTests.swift
+++ b/Tests/StubTests/ClearAllTests.swift
@@ -62,6 +62,112 @@ final class ClearAllTests: XCTestCase {
       XCTAssertFalse(stub.isStubbing)
     }
   }
+
+  #if swift(>=5.6) && canImport(_Concurrency)
+
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  func test_ClearAllWithAsyncStub() async {
+    // given
+    let fetchServices = (0..<10).map { _ in FetchServiceStub() }
+    let saveServices = (0..<10).map { _ in SaveServiceStub() }
+    let asyncFetchServices = (0..<10).map { _ in AsyncFetchServiceStub() }
+    let asyncSaveServices = (0..<10).map { _ in AsyncSaveServiceStub() }
+
+    // Register and invoke to make executions and a stubbing function
+    fetchServices.forEach { fetchService in
+      fetchService.fetchNumberStub.register { completion in
+        completion(0)
+      }
+      fetchService.fetchNumber { _ in }
+    }
+    saveServices.forEach { saveService in
+      saveService.saveNumberStub.register { _ in }
+      saveService.saveNumber(number: 0)
+    }
+    asyncFetchServices.forEach { asyncFetchService in
+      Task {
+        await asyncFetchService.fetchNumberStub.register { completion in
+          completion(0)
+        }
+        await asyncFetchService.fetchNumber { _ in }
+      }
+    }
+    asyncSaveServices.forEach { asyncSaveService in
+      Task {
+        await asyncSaveService.saveNumberStub.register { _ in }
+        await asyncSaveService.saveNumber(number: 0)
+      }
+    }
+
+    let fetchNumberStubs = fetchServices.map(\.fetchNumberStub)
+    let saveNumberStubs = saveServices.map(\.saveNumberStub)
+    let asyncFetchNumberStubs = asyncFetchServices.map(\.fetchNumberStub)
+    let asyncSaveNumberStubs = asyncSaveServices.map(\.saveNumberStub)
+
+    let fetchNumberExecutionsBeforeClearAll = fetchNumberStubs.flatMap { $0.executions() }
+    let saveNumberExecutionsBeforeClearAll = saveNumberStubs.flatMap { $0.executions() }
+    let asyncFetchNumberExecutionsBeforeClearAll = asyncFetchNumberStubs.map { stub in
+      Task { await stub.executions() }
+    }
+    let asyncSaveNumberExecutionsBeforeClearAll = asyncSaveNumberStubs.map { stub in
+      Task { await stub.executions() }
+    }
+    XCTAssertEqual(fetchNumberExecutionsBeforeClearAll.count, 10)
+    XCTAssertEqual(saveNumberExecutionsBeforeClearAll.count, 10)
+    XCTAssertEqual(asyncFetchNumberExecutionsBeforeClearAll.count, 10)
+    XCTAssertEqual(asyncSaveNumberExecutionsBeforeClearAll.count, 10)
+    fetchNumberStubs.forEach { stub in
+      XCTAssertTrue(stub.isStubbing)
+    }
+    saveNumberStubs.forEach { stub in
+      XCTAssertTrue(stub.isStubbing)
+    }
+    asyncFetchNumberStubs.forEach { stub in
+      XCTAssertTrue(stub.isStubbing)
+    }
+    asyncSaveNumberStubs.forEach { stub in
+      XCTAssertTrue(stub.isStubbing)
+    }
+
+    // when
+    Stub.clearAll()
+
+    // then
+    let fetchNumberExecutionsAfterClearAll = fetchNumberStubs.flatMap { $0.executions() }
+    let saveNumberExecutionsAfterClearAll = saveNumberStubs.flatMap { $0.executions() }
+    let asyncFetchNumberExecutionCountAfterClearAll: Int = await {
+      var count = 0
+      for stub in asyncFetchNumberStubs {
+        count += await stub.executions().count
+      }
+      return count
+    }()
+    let asyncSaveNumberExecutionCountAfterClearAll: Int = await {
+      var count = 0
+      for stub in asyncSaveNumberStubs {
+        count += await stub.executions().count
+      }
+      return count
+    }()
+    XCTAssertEqual(fetchNumberExecutionsAfterClearAll.count, 0)
+    XCTAssertEqual(saveNumberExecutionsAfterClearAll.count, 0)
+    XCTAssertEqual(asyncFetchNumberExecutionCountAfterClearAll, 0)
+    XCTAssertEqual(asyncSaveNumberExecutionCountAfterClearAll, 0)
+    fetchNumberStubs.forEach { stub in
+      XCTAssertFalse(stub.isStubbing)
+    }
+    saveNumberStubs.forEach { stub in
+      XCTAssertFalse(stub.isStubbing)
+    }
+    asyncFetchNumberStubs.forEach { stub in
+      XCTAssertFalse(stub.isStubbing)
+    }
+    asyncSaveNumberStubs.forEach { stub in
+      XCTAssertFalse(stub.isStubbing)
+    }
+  }
+
+  #endif
 }
 
 private final class FetchServiceStub {
@@ -77,3 +183,23 @@ private final class SaveServiceStub {
     saveNumberStub.invoke(number)
   }
 }
+
+#if swift(>=5.6) && canImport(_Concurrency)
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+private final class AsyncFetchServiceStub {
+  @AsyncStubProxy(fetchNumber) var fetchNumberStub
+  func fetchNumber(_ completion: @escaping (Int) -> Void) async {
+    await fetchNumberStub.invoke(completion)
+  }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+private final class AsyncSaveServiceStub {
+  @AsyncStubProxy(saveNumber) var saveNumberStub
+  func saveNumber(number: Int) async {
+    await saveNumberStub.invoke(number)
+  }
+}
+
+#endif

--- a/scripts/generate_code
+++ b/scripts/generate_code
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (c) Yoichi Tagaya
+# https://github.com/Swinject/Swinject
+
+files="Sources/Stub/StubProxy/AsyncStubProxy+ArgumentsInitializer Sources/Stub/StubProxy/StubProxy+ArgumentsInitializer"
+
+for file in $files; do
+  echo "Generating code to $file.swift"
+  erb -v -T 1 $file.erb > $file.swift
+done


### PR DESCRIPTION
# Now we can use Swift Concurrency 🙌  (#1)

## How to use?

```swift
@AsyncStubProxy(fetch) var fetchStub
func fetch() async -> String { 
  await fetchStub.invoke(default: "")
}

- - - - -

let convertStubStore = StubStore()
func convert<Source, Target>(_ source: Source) async -> Target {
  let stub = convertStubStore.asyncStub(arguments: Source.self, result: Target.self)
  return await stub.invokeWithoutDefault(value)
}
```

Unfortunately, I couldn't find a way to provide it with the same interface 😢 